### PR TITLE
Add stop in flow before end of flow

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "esversion": 8,
+  "globals": {},
+  "strict": "implied",
+  "browser": true
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,11 @@ repos:
       # Formatter
       - id: ruff-format
 
-  - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.34.1
-    hooks:
-      - id: djlint-reformat-django
-      - id: djlint-django
+#  - repo: https://github.com/Riverside-Healthcare/djLint
+#    rev: v1.36.4
+#    hooks:
+#      - id: djlint-reformat-django
+#      - id: djlint-django
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:

--- a/building_dialouge_webapp/heat/flows.py
+++ b/building_dialouge_webapp/heat/flows.py
@@ -598,7 +598,7 @@ class BuildingTypeFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/building_type.html"
     extra_context = {
         "back_url": "heat:intro_consumption",
-        "next_includes": "#building_type,#monument_protection",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -618,13 +618,23 @@ class BuildingTypeFlow(SidebarNavigationMixin, Flow):
             form_class=forms.BuildingTypeProtectionForm,
             template_name="partials/building_type_protection_help.html",
         ).transition(
-            Switch("monument_protection").case("yes", "dead_end_monument_protection").default("end"),
+            Switch("monument_protection").case("yes", "dead_end_monument_protection").default("stop"),
         )
 
         self.dead_end_monument_protection = EndState(
             self,
             url="heat:dead_end_monument_protection",
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"building_type_done": "True"}',
+            },
+            lookup="building_type_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:building_data")
 
@@ -633,7 +643,7 @@ class BuildingDataFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/building_data.html"
     extra_context = {
         "back_url": "heat:building_type",
-        "next_includes": "#building_data",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -644,8 +654,18 @@ class BuildingDataFlow(SidebarNavigationMixin, Flow):
             form_class=forms.BuildingDataForm,
             template_name="partials/building_data_help.html",
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"building_data_done": "True"}',
+            },
+            lookup="building_data_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:cellar")
 
@@ -654,7 +674,7 @@ class CellarFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/cellar.html"
     extra_context = {
         "back_url": "heat:building_data",
-        "next_includes": "#cellar_heating,#cellar_details,#cellar_insulation_exists,#cellar_insulation_year",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -664,7 +684,7 @@ class CellarFlow(SidebarNavigationMixin, Flow):
             target="cellar_heating",
             form_class=forms.CellarHeatingForm,
         ).transition(
-            Switch("cellar_heating").case("no_cellar", "end").default("cellar_details"),
+            Switch("cellar_heating").case("no_cellar", "stop").default("cellar_details"),
         )
 
         self.cellar_details = FormState(
@@ -680,7 +700,7 @@ class CellarFlow(SidebarNavigationMixin, Flow):
             target="cellar_insulation_exists",
             form_class=forms.CellarInsulationForm,
         ).transition(
-            Switch("cellar_ceiling_insulation_exists").case("doesnt_exist", "end").default("cellar_insulation_year"),
+            Switch("cellar_ceiling_insulation_exists").case("doesnt_exist", "stop").default("cellar_insulation_year"),
         )
 
         self.cellar_insulation_year = FormState(
@@ -688,8 +708,18 @@ class CellarFlow(SidebarNavigationMixin, Flow):
             target="cellar_insulation_year",
             form_class=forms.CellarInsulationYearForm,
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"cellar_done": "True"}',
+            },
+            lookup="cellar_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:hotwater_heating")
 
@@ -698,11 +728,7 @@ class HotwaterHeatingFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/hotwater_heating.html"
     extra_context = {
         "back_url": "heat:cellar",
-        "next_includes": (
-            "#heating_system,#heating_source,#hotwater_heating_system,"
-            "#hotwater_measured,#solar_thermal_exists,#solar_thermal_energy_known,"
-            "#solar_thermal_energy,#solar_thermal_details"
-        ),
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -749,7 +775,7 @@ class HotwaterHeatingFlow(SidebarNavigationMixin, Flow):
             target="solar_thermal_exists",
             form_class=forms.HotwaterHeatingSolarExistsForm,
         ).transition(
-            Switch("solar_thermal_exists").case("doesnt_exist", "end").default("solar_thermal_energy_known"),
+            Switch("solar_thermal_exists").case("doesnt_exist", "stop").default("solar_thermal_energy_known"),
         )
 
         self.solar_thermal_energy_known = FormState(
@@ -768,7 +794,7 @@ class HotwaterHeatingFlow(SidebarNavigationMixin, Flow):
             target="solar_thermal_energy",
             form_class=forms.HotwaterHeatingSolarEnergyForm,
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
 
         self.solar_thermal_details = FormState(
@@ -776,8 +802,18 @@ class HotwaterHeatingFlow(SidebarNavigationMixin, Flow):
             target="solar_thermal_details",
             form_class=forms.HotwaterHeatingSolarDetailsForm,
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"hotwater_heating_done": "True"}',
+            },
+            lookup="hotwater_heating_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:consumption_input")
 
@@ -786,7 +822,7 @@ class ConsumptionInputFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/consumption_input.html"
     extra_context = {
         "back_url": "heat:hotwater_heating",
-        "next_includes": "#consumption_input",
+        "next_disabled": True,
     }
 
     def __init__(self, prefix=None):
@@ -797,8 +833,18 @@ class ConsumptionInputFlow(SidebarNavigationMixin, Flow):
             form_class=forms.ConsumptionInputForm,
             info_text={"next_button": ("Speichern", "Weiter")},
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"consumption_input_done": "True"}',
+            },
+            lookup="consumption_input_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:consumption_overview")
 
@@ -812,9 +858,7 @@ class RoofFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/roof.html"
     extra_context = {
         "back_url": "heat:home",
-        "next_includes": (
-            "#roof_type,#roof_details,#roof_usage_now,#roof_usage_future,#roof_insulation,#roof_insulation_year"
-        ),
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -827,7 +871,7 @@ class RoofFlow(SidebarNavigationMixin, Flow):
         ).transition(
             Switch("roof_type").case("flachdach", "roof_insulation").default("roof_details"),
         )
-        # roof_type results going to roof_details and roof_usage
+
         self.roof_details = FormState(
             self,
             target="roof_details",
@@ -835,6 +879,7 @@ class RoofFlow(SidebarNavigationMixin, Flow):
         ).transition(
             Next("roof_usage_now"),
         )
+
         self.roof_usage_now = FormInfoState(
             self,
             target="roof_usage_now",
@@ -843,25 +888,37 @@ class RoofFlow(SidebarNavigationMixin, Flow):
         ).transition(
             Switch("roof_usage_now").case("all_used", "roof_insulation").default("roof_usage_future"),
         )
-        # roof_usage results going to future usage
+
         self.roof_usage_future = FormState(
             self,
             target="roof_usage_future",
             form_class=forms.RoofUsageFutureForm,
         ).transition(Next("roof_insulation"))
-        # last Form is Insulation
+
         self.roof_insulation = FormState(
             self,
             target="roof_insulation",
             form_class=forms.RoofInsulationForm,
-        ).transition(Switch("roof_insulation_exists").case("yes", "roof_insulation_year").default("end"))
+        ).transition(Switch("roof_insulation_exists").case("yes", "roof_insulation_year").default("stop"))
+
         self.roof_insulation_year = FormState(
             self,
             target="roof_insulation_year",
             form_class=forms.RoofInsulationYearForm,
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"roof_done": "True"}',
+            },
+            lookup="roof_done",
+        ).transition(Next("end"))
+
         self.end = EndState(self, url="heat:window")
 
 
@@ -869,7 +926,7 @@ class WindowFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/window.html"
     extra_context = {
         "back_url": "heat:roof",
-        "next_includes": "#window_area,#window_details",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -888,8 +945,18 @@ class WindowFlow(SidebarNavigationMixin, Flow):
             form_class=forms.WindowDetailsForm,
             template_name="partials/window_details_help.html",
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"window_done": "True"}',
+            },
+            lookup="window_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:facade")
 
@@ -898,7 +965,7 @@ class FacadeFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/facade.html"
     extra_context = {
         "back_url": "heat:window",
-        "next_includes": "#facade_details,#facade_insulation_exists,#facade_insulation_year",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -917,7 +984,7 @@ class FacadeFlow(SidebarNavigationMixin, Flow):
             form_class=forms.FacadeInsulationForm,
             template_name="partials/facade_insulation_help.html",
         ).transition(
-            Switch("facade_insulation_exists").case("exists", "facade_insulation_year").default("end"),
+            Switch("facade_insulation_exists").case("exists", "facade_insulation_year").default("stop"),
         )
 
         self.facade_insulation_year = FormState(
@@ -925,8 +992,18 @@ class FacadeFlow(SidebarNavigationMixin, Flow):
             target="facade_insulation_year",
             form_class=forms.FacadeInsulationYearForm,
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"facade_done": "True"}',
+            },
+            lookup="facade_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:heating")
 
@@ -935,7 +1012,7 @@ class HeatingFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/heating.html"
     extra_context = {
         "back_url": "heat:facade",
-        "next_includes": "#heating,#heating_hydraulic,#heating_details,#heating_storage",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -971,8 +1048,18 @@ class HeatingFlow(SidebarNavigationMixin, Flow):
             form_class=forms.HeatingStorageForm,
             template_name="partials/heating_storage_help.html",
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"heating_done": "True"}',
+            },
+            lookup="heating_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:pv_system")
 
@@ -981,7 +1068,7 @@ class PVSystemFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/pv_system.html"
     extra_context = {
         "back_url": "heat:heating",
-        "next_includes": "#pv_system,#pv_system_planned,#pv_system_details,#pv_system_battery",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -999,7 +1086,7 @@ class PVSystemFlow(SidebarNavigationMixin, Flow):
             target="pv_system_planned",
             form_class=forms.PVSystemPlannedForm,
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
 
         self.pv_system_details = FormState(
@@ -1017,7 +1104,7 @@ class PVSystemFlow(SidebarNavigationMixin, Flow):
             form_class=forms.PVSystemBatteryForm,
             template_name="partials/pv_system_battery_help.html",
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
 
         self.stop = TemplateState(
@@ -1076,6 +1163,7 @@ class RenovationRequestFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/renovation_request.html"
     extra_context = {
         "back_url": "heat:intro_renovation",
+        "next_disabled": True,
     }
 
     def __init__(self, prefix=None):
@@ -1130,8 +1218,18 @@ class RenovationRequestFlow(SidebarNavigationMixin, Flow):
             form_class=forms.RenovationRequestForm,
             info_text={"next_button_text": ("Speichern", "Weiter")},
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"renovation_request_done": "True"}',
+            },
+            lookup="renovation_request_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:renovation_overview")
 

--- a/building_dialouge_webapp/heat/flows.py
+++ b/building_dialouge_webapp/heat/flows.py
@@ -1020,6 +1020,16 @@ class PVSystemFlow(SidebarNavigationMixin, Flow):
             Next("end"),
         )
 
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"pv_system_done": "True"}',
+            },
+            lookup="pv_system_done",
+        ).transition(Next("end"))
+
         self.end = EndState(self, url="heat:ventilation_system")
 
 
@@ -1066,10 +1076,6 @@ class RenovationRequestFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/renovation_request.html"
     extra_context = {
         "back_url": "heat:intro_renovation",
-        "next_includes": (
-            "#primary_heating,#renovation_biomass,#renovation_heatpump,"
-            "#renovation_pvsolar,#renovation_solar,#renovation_details"
-        ),
     }
 
     def __init__(self, prefix=None):
@@ -1139,7 +1145,6 @@ class FinancialSupporFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/financial_support.html"
     extra_context = {
         "back_url": "heat:renovation_request",
-        "next_includes": "#financial_support",
         "next_disabled": True,
         "back_kwargs": "scenario1",
     }
@@ -1159,7 +1164,6 @@ class FinancialSupporFlow(SidebarNavigationMixin, Flow):
             target="next_button",
             template_name="partials/next_button.html",
             context={
-                "next_includes": "#financial_support",
                 "hx_vals": '{"financial_support_done": "True"}',
             },
             lookup="financial_support_done",

--- a/building_dialouge_webapp/heat/flows.py
+++ b/building_dialouge_webapp/heat/flows.py
@@ -1027,7 +1027,7 @@ class VentilationSystemFlow(SidebarNavigationMixin, Flow):
     template_name = "pages/ventilation_system.html"
     extra_context = {
         "back_url": "heat:pv_system",
-        "next_includes": "#ventilation_system_exists,#ventilation_system_year",
+        "next_disabled": True,
     }
 
     def __init__(self):
@@ -1038,7 +1038,7 @@ class VentilationSystemFlow(SidebarNavigationMixin, Flow):
             form_class=forms.VentilationSystemForm,
             template_name="partials/ventilation_system_help.html",
         ).transition(
-            Switch("ventilation_system_exists").case("doesnt_exist", "end").default("ventilation_system_year"),
+            Switch("ventilation_system_exists").case("doesnt_exist", "stop").default("ventilation_system_year"),
         )
 
         self.ventilation_system_year = FormState(
@@ -1046,8 +1046,18 @@ class VentilationSystemFlow(SidebarNavigationMixin, Flow):
             target="ventilation_system_year",
             form_class=forms.VentilationSystemYearForm,
         ).transition(
-            Next("end"),
+            Next("stop"),
         )
+
+        self.stop = TemplateState(
+            self,
+            target="next_button",
+            template_name="partials/next_button.html",
+            context={
+                "hx_vals": '{"ventilation_system_done": "True"}',
+            },
+            lookup="ventilation_system_done",
+        ).transition(Next("end"))
 
         self.end = EndState(self, url="heat:intro_renovation")
 

--- a/building_dialouge_webapp/static/css/project.scss
+++ b/building_dialouge_webapp/static/css/project.scss
@@ -18,3 +18,7 @@
   background-color: #f2dede;
   border-color: #eed3d7;
 }
+
+a.disabled {
+    pointer-events: none;
+}

--- a/building_dialouge_webapp/static/js/flow_validation.js
+++ b/building_dialouge_webapp/static/js/flow_validation.js
@@ -1,0 +1,26 @@
+// Listen for HTMX events and handle validation for all forms
+document.addEventListener("htmx:beforeRequest", (event) => {
+  const form = event.target.closest(".main"); // Target the closest form
+  if (!form) return;
+
+  const requiredFields = form.querySelectorAll("[required]");
+  let allValid = true;
+
+  requiredFields.forEach((field) => {
+    if (field.type === "radio" || field.type === "checkbox") {
+      // RadioButtons and Checkboxes
+      const group = form.querySelectorAll(`[name="${field.name}"]`);
+      const isChecked = Array.from(group).some((input) => input.checked);
+      if (!isChecked) allValid = false;
+    } else if (field.tagName === "SELECT") {
+      // Select Fields
+      if (!field.value) allValid = false;
+    } else {
+      // For text, number, or other inputs
+      if (!field.value.trim()) allValid = false;
+    }
+  });
+  if (!allValid) {
+    event.preventDefault(); // Stop the HTMX request
+  }
+});

--- a/building_dialouge_webapp/templates/base.html
+++ b/building_dialouge_webapp/templates/base.html
@@ -34,7 +34,7 @@
       {% endcompress %}
     {% endblock javascript %}
   </head>
-  <body class="{% block bodyclass %}{% endblock bodyclass %} d-flex flex-column h-100">
+  <body class="{% block bodyclass %}{% endblock bodyclass %} d-flex flex-column h-100" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     {% block body %}
       <div class="flex-shrink-0">
         <nav class="navbar navbar-expand-md navbar-light bg-white border-bottom">

--- a/building_dialouge_webapp/templates/base_footer_button.html
+++ b/building_dialouge_webapp/templates/base_footer_button.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load static %}
+
 {% block footer %}
   <div class="footer bg-white border-top">
     <div class="container-fluid d-flex justify-content-center py-2 px-4">
@@ -26,34 +28,10 @@
         </div>
       </div>
     </div>
-    <script>
-    // Listen for HTMX events and handle validation for all forms
-      document.addEventListener('htmx:beforeRequest', (event) => {
-          const form = event.target.closest('.main'); // Target the closest form
-          if (!form) return;
-
-          const requiredFields = form.querySelectorAll('[required]');
-          let allValid = true;
-
-          requiredFields.forEach(field => {
-              if (field.type === 'radio' || field.type === 'checkbox') {
-                // RadioButtons and Checkboxes
-                  const group = form.querySelectorAll(`[name="${field.name}"]`);
-                  const isChecked = Array.from(group).some(input => input.checked);
-                  if (!isChecked) allValid = false;
-              } else if (field.tagName === 'SELECT') {
-                // Select Fields
-                  if (!field.value) allValid = false;
-              } else {
-                  // For text, number, or other inputs
-                  if (!field.value.trim()) allValid = false;
-              }
-          });
-          if (!allValid) {
-              event.preventDefault(); // Stop the HTMX request
-          }
-      });
-    </script>
-
     {{ block.super }}
   {% endblock footer %}
+
+{% block javascript %}
+  {{ block.super }}
+  <script defer src="{% static 'js/flow_validation.js' %}"></script>
+{% endblock javascript %}

--- a/building_dialouge_webapp/templates/base_footer_button.html
+++ b/building_dialouge_webapp/templates/base_footer_button.html
@@ -48,12 +48,7 @@
                   // For text, number, or other inputs
                   if (!field.value.trim()) allValid = false;
               }
-
-              const parent = field.closest('fieldset') || field.closest('div') || field;
-              if (!allValid) {
-              }
           });
-
           if (!allValid) {
               event.preventDefault(); // Stop the HTMX request
           }

--- a/building_dialouge_webapp/templates/base_footer_button.html
+++ b/building_dialouge_webapp/templates/base_footer_button.html
@@ -5,13 +5,13 @@
     <div class="container-fluid d-flex justify-content-center py-2 px-4">
       <div class="d-flex gap-3">
         {# Back button is a simple link to given URL #}
+        <!-- djlint:off H025 -->
         {% if back_kwargs %}
-          <!-- djlint:off H025 -->
           <a class="btn btn-light" href="{% url back_url scenario=back_kwargs %}">
-            <!-- djlint:on -->
           {% else %}
             <a class="btn btn-light" href="{% url back_url %}">
             {% endif %}
+            <!-- djlint:on -->
             <svg xmlns="http://www.w3.org/2000/svg"
                  width="16"
                  height="16"
@@ -22,43 +22,9 @@
             </svg>
             <span class="ps-2">Zurück</span>
           </a>
-          {# Next button in flow is always a HTMX call to current page including several form inputs. #}
-          {% if next_includes %}
-            <a class="btn btn-primary" hx-post="" hx-include="{{ next_includes }}">
-              <span class="ps-2" id="next_button">Weiter</span>
-              <svg xmlns="http://www.w3.org/2000/svg"
-                   width="16"
-                   height="16"
-                   fill="currentColor"
-                   class="bi bi-arrow-right"
-                   viewBox="0 0 16 16">
-                <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8" />
-              </svg>
-            </a>
-          {% endif %}
-          {% if next_url %}
-            {% if next_kwargs %}
-              <!-- djlint:off H025 -->
-              <a class="btn btn-primary"
-                 href="{% url next_url scenario=next_kwargs %}">
-                <!-- djlint:on -->
-              {% else %}
-                <a class="btn btn-primary" href="{% url next_url %}">
-                {% endif %}
-                <span class="ps-2">Weiter</span>
-                <svg xmlns="http://www.w3.org/2000/svg"
-                     width="16"
-                     height="16"
-                     fill="currentColor"
-                     class="bi bi-arrow-right"
-                     viewBox="0 0 16 16">
-                  <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8" />
-                </svg>
-              </a>
-            {% else %}
-            {% endif %}
-          </div>
+          {% include "partials/next_button.html" %}
         </div>
       </div>
-      {{ block.super }}
-    {% endblock footer %}
+    </div>
+    {{ block.super }}
+  {% endblock footer %}

--- a/building_dialouge_webapp/templates/base_footer_button.html
+++ b/building_dialouge_webapp/templates/base_footer_button.html
@@ -22,7 +22,7 @@
             </svg>
             <span class="ps-2">Zurück</span>
           </a>
-          {% include "partials/next_button.html" %}
+          <div id="next_button">{% include "partials/next_button.html" %}</div>
         </div>
       </div>
     </div>

--- a/building_dialouge_webapp/templates/base_footer_button.html
+++ b/building_dialouge_webapp/templates/base_footer_button.html
@@ -26,5 +26,39 @@
         </div>
       </div>
     </div>
+    <script>
+    // Listen for HTMX events and handle validation for all forms
+      document.addEventListener('htmx:beforeRequest', (event) => {
+          const form = event.target.closest('.main'); // Target the closest form
+          if (!form) return;
+
+          const requiredFields = form.querySelectorAll('[required]');
+          let allValid = true;
+
+          requiredFields.forEach(field => {
+              if (field.type === 'radio' || field.type === 'checkbox') {
+                // RadioButtons and Checkboxes
+                  const group = form.querySelectorAll(`[name="${field.name}"]`);
+                  const isChecked = Array.from(group).some(input => input.checked);
+                  if (!isChecked) allValid = false;
+              } else if (field.tagName === 'SELECT') {
+                // Select Fields
+                  if (!field.value) allValid = false;
+              } else {
+                  // For text, number, or other inputs
+                  if (!field.value.trim()) allValid = false;
+              }
+
+              const parent = field.closest('fieldset') || field.closest('div') || field;
+              if (!allValid) {
+              }
+          });
+
+          if (!allValid) {
+              event.preventDefault(); // Stop the HTMX request
+          }
+      });
+    </script>
+
     {{ block.super }}
   {% endblock footer %}

--- a/building_dialouge_webapp/templates/pages/building_data.html
+++ b/building_dialouge_webapp/templates/pages/building_data.html
@@ -11,6 +11,9 @@
       </div>
       <div class="help"></div>
     </div>
-    <div id="building_data">{{ building_data.content | safe }}</div>
+    <div id="building_data"
+      hx-post=""
+      hx-trigger="keyup change delay:500ms, change"
+      hx-include="this">{{ building_data.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/building_type.html
+++ b/building_dialouge_webapp/templates/pages/building_type.html
@@ -12,6 +12,9 @@
       <div class="help"></div>
     </div>
     <div id="building_type" hx-post="" hx-trigger="change" hx-include="this">{{ building_type.content | safe }}</div>
-    <div id="monument_protection">{{ monument_protection.content | safe }}</div>
+    <div id="monument_protection"
+      hx-post=""
+      hx-trigger="change"
+      hx-include="this">{{ monument_protection.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/cellar.html
+++ b/building_dialouge_webapp/templates/pages/cellar.html
@@ -13,25 +13,41 @@
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="cellar_heating" class="main">{{ cellar_heating.content | safe }}</div>
+        <div id="cellar_heating"
+          hx-post=""
+          hx-trigger="change"
+          hx-include="this"
+          class="main">{{ cellar_heating.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="cellar_details" class="main">{{ cellar_details.content | safe }}</div>
+        <div id="cellar_details"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ cellar_details.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="cellar_insulation_exists" class="main">{{ cellar_insulation_exists.content | safe }}</div>
+        <div id="cellar_insulation_exists"
+          hx-post=""
+          hx-trigger="change"
+          hx-include="this"
+          class="main">{{ cellar_insulation_exists.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="cellar_insulation_year" class="main">{{ cellar_insulation_year.content | safe }}</div>
+        <div id="cellar_insulation_year"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ cellar_insulation_year.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>

--- a/building_dialouge_webapp/templates/pages/consumption_input.html
+++ b/building_dialouge_webapp/templates/pages/consumption_input.html
@@ -13,7 +13,11 @@
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="consumption_input" class="main">{{ consumption_input.content | safe }}</div>
+        <div id="consumption_input"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ consumption_input.content | safe }}</div>
         <div class="help" id="flow-instance-boxes">
           {% for box in year_boxes %}
             <c-flow-instance-box id="{{ box.id }}" href="{{ box.href }}" title="{{ box.title }}" text="{{ box.text }}" />

--- a/building_dialouge_webapp/templates/pages/facade.html
+++ b/building_dialouge_webapp/templates/pages/facade.html
@@ -21,10 +21,17 @@
         <div class="help"></div>
       </div>
     </div>
-    <div id="facade_insulation_exists">{{ facade_insulation_exists.content | safe }}</div>
+    <div id="facade_insulation_exists"
+      hx-post=""
+      hx-trigger="change"
+      hx-include="this">{{ facade_insulation_exists.content | safe }}</div>
     <div class="step-question">
       <div class="step-container">
-        <div id="facade_insulation_year" class="main">{{ facade_insulation_year.content | safe }}</div>
+        <div id="facade_insulation_year"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ facade_insulation_year.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>

--- a/building_dialouge_webapp/templates/pages/financial_support.html
+++ b/building_dialouge_webapp/templates/pages/financial_support.html
@@ -15,6 +15,6 @@
          hx-post=""
          hx-trigger="change"
          hx-include="this"
-         hx-swap="outerHTML">{{ financial_support.content | safe }}</div>
+    >{{ financial_support.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/financial_support.html
+++ b/building_dialouge_webapp/templates/pages/financial_support.html
@@ -11,6 +11,10 @@
       </div>
       <div class="help"></div>
     </div>
-    <div id="financial_support">{{ financial_support.content | safe }}</div>
+    <div id="financial_support"
+         hx-post=""
+         hx-trigger="change"
+         hx-include="this"
+         hx-swap="outerHTML">{{ financial_support.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/heating.html
+++ b/building_dialouge_webapp/templates/pages/heating.html
@@ -13,7 +13,11 @@
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="heating" class="main">{{ heating.content | safe }}</div>
+        <div id="heating"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms, change"
+          hx-include="this"
+          class="main">{{ heating.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
@@ -31,6 +35,9 @@
         <div class="help"></div>
       </div>
     </div>
-    <div id="heating_storage">{{ heating_storage.content | safe }}</div>
+    <div id="heating_storage"
+      hx-post=""
+      hx-trigger="keyup change delay:500ms"
+      hx-include="this">{{ heating_storage.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/heating.html
+++ b/building_dialouge_webapp/templates/pages/heating.html
@@ -41,27 +41,4 @@
       hx-trigger="keyup change delay:500ms"
       hx-include="this">{{ heating_storage.content | safe }}</div>
   </section>
-<script>
-    // Listen for HTMX events and handle stop if user hasn't filled out entire form
-    document.addEventListener('htmx:beforeRequest', (event) => {
-        console.log("inside beforeRequest")
-        const form = event.target.closest('#heating_details');
-        if (!form) return;
-        console.log(form)
-
-        const requiredFields = form.querySelectorAll('input[required]');
-        let allValid = true;
-
-        requiredFields.forEach(field => {
-            const group = form.querySelectorAll(`input[name="${field.name}"]`);
-            if (!Array.from(group).some(input => input.checked)) {
-                allValid = false;
-            }
-        });
-
-        if (!allValid) {
-            event.preventDefault(); // Prevent the HTMX request
-        }
-    });
-  </script>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/heating.html
+++ b/building_dialouge_webapp/templates/pages/heating.html
@@ -31,7 +31,8 @@
              hx-post=""
              hx-trigger="change"
              hx-include="this"
-             class="main">{{ heating_details.content | safe }}</div>
+             class="main">{{ heating_details.content | safe }}
+             </div>
         <div class="help"></div>
       </div>
     </div>
@@ -40,4 +41,27 @@
       hx-trigger="keyup change delay:500ms"
       hx-include="this">{{ heating_storage.content | safe }}</div>
   </section>
+<script>
+    // Listen for HTMX events and handle stop if user hasn't filled out entire form
+    document.addEventListener('htmx:beforeRequest', (event) => {
+        console.log("inside beforeRequest")
+        const form = event.target.closest('#heating_details');
+        if (!form) return;
+        console.log(form)
+
+        const requiredFields = form.querySelectorAll('input[required]');
+        let allValid = true;
+
+        requiredFields.forEach(field => {
+            const group = form.querySelectorAll(`input[name="${field.name}"]`);
+            if (!Array.from(group).some(input => input.checked)) {
+                allValid = false;
+            }
+        });
+
+        if (!allValid) {
+            event.preventDefault(); // Prevent the HTMX request
+        }
+    });
+  </script>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/hotwater_heating.html
+++ b/building_dialouge_webapp/templates/pages/hotwater_heating.html
@@ -11,7 +11,10 @@
       </div>
       <div class="help"></div>
     </div>
-    <div id="heating_system">{{ heating_system.content | safe }}</div>
+    <div id="heating_system"
+      hx-post=""
+      hx-trigger="change"
+      hx-include="this">{{ heating_system.content | safe }}</div>
     <div id="heating_source" hx-post="" hx-trigger="change" hx-include="this">{{ heating_source.content | safe }}</div>
     <div id="hotwater_heating_system"
          hx-post=""
@@ -29,7 +32,11 @@
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="solar_thermal_exists" class="main">{{ solar_thermal_exists.content | safe }}</div>
+        <div id="solar_thermal_exists"
+          hx-post=""
+          hx-trigger="change"
+          hx-include="this"
+          class="main">{{ solar_thermal_exists.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
@@ -39,13 +46,21 @@
          hx-include="this">{{ solar_thermal_energy_known.content | safe }}</div>
     <div class="step-question">
       <div class="step-container">
-        <div id="solar_thermal_energy" class="main">{{ solar_thermal_energy.content | safe }}</div>
+        <div id="solar_thermal_energy"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ solar_thermal_energy.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="solar_thermal_details" class="main">{{ solar_thermal_details.content | safe }}</div>
+        <div id="solar_thermal_details"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms, change"
+          hx-include="this"
+          class="main">{{ solar_thermal_details.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>

--- a/building_dialouge_webapp/templates/pages/pv_system.html
+++ b/building_dialouge_webapp/templates/pages/pv_system.html
@@ -23,11 +23,21 @@
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="pv_system_planned" class="main">{{ pv_system_planned.content | safe }}</div>
+        <div id="pv_system_planned"
+          hx-post=""
+          hx-trigger="change"
+          hx-include="this"
+          class="main">{{ pv_system_planned.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
-    <div id="pv_system_details">{{ pv_system_details.content | safe }}</div>
-    <div id="pv_system_battery">{{ pv_system_battery.content | safe }}</div>
+    <div id="pv_system_details"
+      hx-post=""
+      hx-trigger="keyup change delay:500ms"
+      hx-include="this">{{ pv_system_details.content | safe }}</div>
+    <div id="pv_system_battery"
+      hx-post=""
+      hx-trigger="keyup change delay:500ms, change"
+      hx-include="this">{{ pv_system_battery.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/renovation_request.html
+++ b/building_dialouge_webapp/templates/pages/renovation_request.html
@@ -67,7 +67,11 @@
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="renovation_details" class="main">{{ renovation_details.content | safe }}</div>
+        <div id="renovation_details"
+          hx-post=""
+          hx-trigger="change"
+          hx-include="this"
+          class="main">{{ renovation_details.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>

--- a/building_dialouge_webapp/templates/pages/roof.html
+++ b/building_dialouge_webapp/templates/pages/roof.html
@@ -14,7 +14,11 @@
     <div id="roof_type" hx-post="" hx-trigger="change" hx-include="this">{{ roof_type.content | safe }}</div>
     <div class="step-question">
       <div class="step-container">
-        <div id="roof_details" class="main">{{ roof_details.content | safe }}</div>
+        <div id="roof_details"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ roof_details.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
@@ -30,19 +34,31 @@
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="roof_usage_future" class="main">{{ roof_usage_future.content | safe }}</div>
+        <div id="roof_usage_future"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ roof_usage_future.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="roof_insulation" class="main">{{ roof_insulation.content | safe }}</div>
+        <div id="roof_insulation"
+          hx-post=""
+          hx-trigger="change"
+          hx-include="this"
+          class="main">{{ roof_insulation.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>
     <div class="step-question">
       <div class="step-container">
-        <div id="roof_insulation_year" class="main">{{ roof_insulation_year.content | safe }}</div>
+        <div id="roof_insulation_year"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ roof_insulation_year.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>

--- a/building_dialouge_webapp/templates/pages/ventilation_system.html
+++ b/building_dialouge_webapp/templates/pages/ventilation_system.html
@@ -11,10 +11,17 @@
       </div>
       <div class="help"></div>
     </div>
-    <div id="ventilation_system_exists">{{ ventilation_system_exists.content | safe }}</div>
+    <div id="ventilation_system_exists"
+      hx-post=""
+      hx-trigger="change"
+      hx-include="this">{{ ventilation_system_exists.content | safe }}</div>
     <div class="step-question">
       <div class="step-container">
-        <div id="ventilation_system_year" class="main">{{ ventilation_system_year.content | safe }}</div>
+        <div id="ventilation_system_year"
+          hx-post=""
+          hx-trigger="keyup change delay:500ms"
+          hx-include="this"
+          class="main">{{ ventilation_system_year.content | safe }}</div>
         <div class="help"></div>
       </div>
     </div>

--- a/building_dialouge_webapp/templates/pages/window.html
+++ b/building_dialouge_webapp/templates/pages/window.html
@@ -21,6 +21,9 @@
         <div class="help"></div>
       </div>
     </div>
-    <div id="window_details">{{ window_details.content | safe }}</div>
+    <div id="window_details"
+      hx-post=""
+      hx-trigger="keyup change delay:500ms"
+      hx-include="this">{{ window_details.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/partials/next_button.html
+++ b/building_dialouge_webapp/templates/partials/next_button.html
@@ -1,7 +1,6 @@
 {# Next button in flow is always a HTMX call to current page including several form inputs. #}
 {% if next_includes %}
-  <a id="next_button"
-     class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
+  <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
      hx-post=""
      hx-include="{{ next_includes }}"
      hx-vals='{{ hx_vals }}'
@@ -9,12 +8,10 @@
 {% else %}
   {% if next_url %}
     {% if next_kwargs %}
-      <a id="next_button"
-         class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
+      <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
          href="{% url next_url scenario=next_kwargs %}">
     {% else %}
-      <a id="next_button"
-         class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
+      <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
          href="{% url next_url %}">
     {% endif %}
   {% endif %}

--- a/building_dialouge_webapp/templates/partials/next_button.html
+++ b/building_dialouge_webapp/templates/partials/next_button.html
@@ -12,7 +12,7 @@
   {# Next button in flow is always a HTMX call to current page including several form inputs. #}
   {# Used in flow when first loading the Button or loading it with stop state. #}
     <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
-      hx-get=""
+      hx-post=""
       {% if hx_vals %}
       hx-vals='{{ hx_vals }}'
       {% endif %}

--- a/building_dialouge_webapp/templates/partials/next_button.html
+++ b/building_dialouge_webapp/templates/partials/next_button.html
@@ -1,0 +1,29 @@
+{# Next button in flow is always a HTMX call to current page including several form inputs. #}
+{% if next_includes %}
+  <a id="next_button"
+     class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
+     hx-post=""
+     hx-include="{{ next_includes }}">
+{% else %}
+  {% if next_url %}
+    {% if next_kwargs %}
+      <a id="next_button"
+         class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
+         href="{% url next_url scenario=next_kwargs %}">
+    {% else %}
+      <a id="next_button"
+         class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
+         href="{% url next_url %}">
+    {% endif %}
+  {% endif %}
+{% endif %}
+  <span class="ps-2" id="next_button_text">Weiter</span>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       width="16"
+       height="16"
+       fill="currentColor"
+       class="bi bi-arrow-right"
+       viewBox="0 0 16 16">
+    <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8" />
+  </svg>
+</a>

--- a/building_dialouge_webapp/templates/partials/next_button.html
+++ b/building_dialouge_webapp/templates/partials/next_button.html
@@ -1,20 +1,22 @@
-{# Next button in flow is always a HTMX call to current page including several form inputs. #}
-{% if next_includes %}
-  <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
-     hx-post=""
-     hx-include="{{ next_includes }}"
-     hx-vals='{{ hx_vals }}'
-  >
-{% else %}
-  {% if next_url %}
+{% if next_url %}
+  {# Used in views. #}
     {% if next_kwargs %}
+    {# KWARGS are True on when next page has prefix. #}
       <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
          href="{% url next_url scenario=next_kwargs %}">
     {% else %}
       <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
          href="{% url next_url %}">
     {% endif %}
-  {% endif %}
+{% else %}
+  {# Next button in flow is always a HTMX call to current page including several form inputs. #}
+  {# Used in flow when first loading the Button or loading it with stop state. #}
+    <a class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
+      hx-get=""
+      {% if hx_vals %}
+      hx-vals='{{ hx_vals }}'
+      {% endif %}
+    >
 {% endif %}
   <span class="ps-2" id="next_button_text">Weiter</span>
   <svg xmlns="http://www.w3.org/2000/svg"

--- a/building_dialouge_webapp/templates/partials/next_button.html
+++ b/building_dialouge_webapp/templates/partials/next_button.html
@@ -3,7 +3,9 @@
   <a id="next_button"
      class="btn btn-primary {% if next_disabled %}disabled{% endif %}"
      hx-post=""
-     hx-include="{{ next_includes }}">
+     hx-include="{{ next_includes }}"
+     hx-vals='{{ hx_vals }}'
+  >
 {% else %}
   {% if next_url %}
     {% if next_kwargs %}


### PR DESCRIPTION
This PR adds an additional stop node in financial support flow, which introduces a step before going on to next flow and alos activates the "Weiter" button.
This can be used in the other flows as well, so that we can implement "onchange" behaviour for all nodes.