### PR TITLE
Fix/renovations page

### DIFF
--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -450,13 +450,13 @@ class RenovationRequestForm(ValidationForm):
         widget=forms.CheckboxSelectMultiple,
         required=False,
     )
-    facade_renovation_details = forms.ChoiceField(
+    facade_renovation_details = forms.MultipleChoiceField(
         label="",
         choices=[
             ("facade_insulate_renovation", "Fassade dämmen"),
             ("facade_glaster_renovation", "Fassade verputzen"),
         ],
-        widget=forms.RadioSelect,
+        widget=forms.CheckboxSelectMultiple,
         required=False,
     )
     roof_renovation_choice = forms.MultipleChoiceField(
@@ -467,13 +467,13 @@ class RenovationRequestForm(ValidationForm):
         widget=forms.CheckboxSelectMultiple,
         required=False,
     )
-    roof_renovation_details = forms.ChoiceField(
+    roof_renovation_details = forms.MultipleChoiceField(
         label="",
         choices=[
             ("cover", "Dach decken"),
             ("expand", "Dach ausbauen"),
         ],
-        widget=forms.RadioSelect,
+        widget=forms.CheckboxSelectMultiple,
         required=False,
     )
     window_renovation_choice = forms.MultipleChoiceField(

--- a/building_dialouge_webapp/heat/views.py
+++ b/building_dialouge_webapp/heat/views.py
@@ -251,7 +251,7 @@ def get_user_friendly_data(scenario_data, form_classes: list) -> list:
     # remove duplicates
     choices = list(dict.fromkeys(choices))
     # remove categories that have further specification
-    top_categories = ["Biomasseheizung", "Wärmepumpe", "Dach", "Fassade"]
+    top_categories = ["Biomasseheizung", "Wärmepumpe", "Dach:", "Fassade:"]
     for category in top_categories:
         if category in choices:
             choices.remove(category)

--- a/building_dialouge_webapp/static/js/renovation_checkboxes.js
+++ b/building_dialouge_webapp/static/js/renovation_checkboxes.js
@@ -1,30 +1,69 @@
+document.addEventListener("htmx:afterSwap", setupRenovationCheckboxLogic);
+document.addEventListener("DOMContentLoaded", setupRenovationCheckboxLogic);
 
-document.addEventListener("htmx:afterSwap", function () {
-    document.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
-      const name = checkbox.name;
-
-      if (name.endsWith("-roof_renovation_choice")) {
-        checkbox.addEventListener("change", function () {
-          const prefix = name.replace("-roof_renovation_choice", "");
-          const radios = document.querySelectorAll(
-            `input[name="${prefix}-roof_renovation_details"]`
-          );
-          if (!checkbox.checked) {
-            radios.forEach((radio) => (radio.checked = false));
+function setupRenovationCheckboxLogic() {
+  document.querySelectorAll("form").forEach((form) => {
+    form.addEventListener("submit", () => {
+      // For each renovation group, deselect details if main choice is unchecked
+      ["roof", "facade"].forEach((section) => {
+        const mainCheckboxes = form.querySelectorAll(
+          `input[name$="-${section}_renovation_choice"]`
+        );
+        mainCheckboxes.forEach((mainCheckbox) => {
+          const prefix = mainCheckbox.name.replace(`-${section}_renovation_choice`, "");
+          if (!mainCheckbox.checked) {
+            const detailCheckboxes = form.querySelectorAll(
+              `input[name="${prefix}-${section}_renovation_details"]`
+            );
+            detailCheckboxes.forEach((cb) => (cb.checked = false));
           }
         });
-      }
-
-      if (name.endsWith("-facade_renovation_choice")) {
-        checkbox.addEventListener("change", function () {
-          const prefix = name.replace("-facade_renovation_choice", "");
-          const radios = document.querySelectorAll(
-            `input[name="${prefix}-facade_renovation_details"]`
-          );
-          if (!checkbox.checked) {
-            radios.forEach((radio) => (radio.checked = false));
-          }
-        });
-      }
+      });
     });
   });
+
+  // Keep your change event handlers for live interaction:
+  document.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+    const name = checkbox.name;
+
+    if (name.endsWith("-roof_renovation_choice")) {
+      checkbox.addEventListener("change", () => {
+        const prefix = name.replace("-roof_renovation_choice", "");
+        const details = document.querySelectorAll(
+          `input[name="${prefix}-roof_renovation_details"]`
+        );
+        if (!checkbox.checked) details.forEach((cb) => (cb.checked = false));
+      });
+    }
+
+    if (name.endsWith("-roof_renovation_details")) {
+      checkbox.addEventListener("change", () => {
+        const prefix = name.replace("-roof_renovation_details", "");
+        const main = document.querySelector(
+          `input[name="${prefix}-roof_renovation_choice"]`
+        );
+        if (checkbox.checked && main && !main.checked) main.checked = true;
+      });
+    }
+
+    if (name.endsWith("-facade_renovation_choice")) {
+      checkbox.addEventListener("change", () => {
+        const prefix = name.replace("-facade_renovation_choice", "");
+        const details = document.querySelectorAll(
+          `input[name="${prefix}-facade_renovation_details"]`
+        );
+        if (!checkbox.checked) details.forEach((cb) => (cb.checked = false));
+      });
+    }
+
+    if (name.endsWith("-facade_renovation_details")) {
+      checkbox.addEventListener("change", () => {
+        const prefix = name.replace("-facade_renovation_details", "");
+        const main = document.querySelector(
+          `input[name="${prefix}-facade_renovation_choice"]`
+        );
+        if (checkbox.checked && main && !main.checked) main.checked = true;
+      });
+    }
+  });
+}

--- a/building_dialouge_webapp/templates/pages/renovation_overview.html
+++ b/building_dialouge_webapp/templates/pages/renovation_overview.html
@@ -7,8 +7,7 @@
         <div class="main">
           <h1>Sanierungsübersicht</h1>
           <div class="info-box">
-            Hier fügen Sie Szenarien für den Heizungstausch und Sanierungsmaßnahmen hinzu. <br>
-            Sie können bis zu 3 Szenarien berechnen.
+            <p>Klicken Sie auf „Weiteres Heizszenario“, um eines von bis zu drei Heizszenarien zu erstellen. Wählen Sie eine primäre Heiztechnologie aus und ergänzen Sie bei Bedarf zusätzliche Energieerzeuger und Dämmmaßnahmen. So können Sie verschiedene Varianten vergleichen.</p>
           </div>
           <form action="{% url 'heat:renovation_request' scenario='new_scenario' %}" method="get">
             <button class="btn btn-primary" {% if max_reached %}disabled{% endif %}>Weiteres Heizszenario</button>


### PR DESCRIPTION
changed radiobuttons to checkboxes on renovation request page, as descibed in #151 
![image](https://github.com/user-attachments/assets/7438f4dc-0c10-40c5-ae4c-fcc108e7f701)
![image](https://github.com/user-attachments/assets/299558a2-9ce3-4007-a98a-d6889094717a)

The checkboxes still have the same behavior (when selecting a specification "Fassade" or "Dach" gets selected as well, and when deselecting "Fassade" or "Dach" the specifications get deselected) 

added text to scenario overview and checked coherence of all units. 
![image](https://github.com/user-attachments/assets/8b32d96c-7d3a-4aff-bac2-254571344666)
