### PR TITLE
Fix/move explaining texts

### DIFF
--- a/building_dialouge_webapp/heat/flows.py
+++ b/building_dialouge_webapp/heat/flows.py
@@ -693,7 +693,7 @@ class HeatingFlow(SidebarNavigationMixin, Flow):
             self,
             target="solar_thermal_exists",
             form_class=forms.HeatingSolarExistsForm,
-            template_name="partials/hotwater_heating_solar_help.html",
+            template_name="partials/heating_solar_help.html",
         ).transition(
             Switch("solar_thermal_exists").case("doesnt_exist", "stop").default("solar_thermal_area"),
         )

--- a/building_dialouge_webapp/heat/flows.py
+++ b/building_dialouge_webapp/heat/flows.py
@@ -600,6 +600,14 @@ class BuildingTypeFlow(SidebarNavigationMixin, Flow):
             form_class=forms.BuildingTypeForm,
             template_name="partials/building_type_help.html",
         ).transition(
+            Next("building_details"),
+        )
+
+        self.building_details = FormState(
+            self,
+            target="building_details",
+            form_class=forms.BuildingDetailsForm,
+        ).transition(
             Next("monument_protection"),
         )
 

--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -262,19 +262,6 @@ class HeatingStorageCapacityForm(ValidationForm):
     )
 
 
-class RoofTypeSelect(RadioSelect):
-    template_name = "forms/energy_source.html"
-
-    INFOS = {
-        "exists": "Besitzt ihr Gebäude ein Flachdach?",
-    }
-
-    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):  # noqa: PLR0913
-        option = super().create_option(name, value, label, selected, index, subindex, attrs)
-        option["info"] = self.INFOS.get(value, "")
-        return option
-
-
 class RoofTypeForm(forms.Form):
     flat_roof = forms.ChoiceField(
         label="Flachdach",
@@ -282,7 +269,7 @@ class RoofTypeForm(forms.Form):
             ("exists", "Ja"),
             ("doesnt_exist", "Nein"),
         ],
-        widget=RoofTypeSelect(),
+        widget=forms.RadioSelect,
     )
 
 

--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -340,7 +340,6 @@ class PVSystemBatteryCapacityForm(ValidationForm):
     battery_capacity = forms.IntegerField(
         label="Speicherkapazität in kWh",
         widget=forms.NumberInput(attrs={"class": "form-control"}),
-        template_name="forms/pv-battery-capacity.html",
     )
 
 

--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -69,6 +69,9 @@ class BuildingTypeForm(ValidationForm):
         ],
         widget=HouseTypeSelect(),
     )
+
+
+class BuildingDetailsForm(ValidationForm):
     construction_year = forms.IntegerField(
         label="Baujahr",
         widget=forms.NumberInput(attrs={"class": "form-control"}),

--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -317,7 +317,6 @@ class PVSystemCapacityForm(ValidationForm):
     pv_capacity = forms.IntegerField(
         label="Nennleistung in kWp",
         widget=forms.NumberInput(attrs={"class": "form-control"}),
-        template_name="forms/pv-capacity.html",
     )
 
 

--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -259,7 +259,6 @@ class HeatingStorageCapacityForm(ValidationForm):
     heating_storage_capacity = forms.IntegerField(
         label="Wärmespeicher Fassungsvermögen in l",
         widget=forms.NumberInput(attrs={"class": "form-control"}),
-        template_name="forms/heating-storage-capacity.html",
     )
 
 

--- a/building_dialouge_webapp/templates/forms/heating-storage-capacity.html
+++ b/building_dialouge_webapp/templates/forms/heating-storage-capacity.html
@@ -1,2 +1,0 @@
-{%  include "django/forms/field.html" %}
-<span class="info-text info-text--form">Das Fassungsvermögen eines Wärmespeichers hängt von der Größe des Gebäudes und dem individuellen Wärmebedarf ab, wobei gängige Größen zwischen 300 und 1.000 Litern liegen, um ausreichend Warmwasser und Heizenergie bereitstellen zu können.</span>

--- a/building_dialouge_webapp/templates/forms/pv-battery-capacity.html
+++ b/building_dialouge_webapp/templates/forms/pv-battery-capacity.html
@@ -1,2 +1,0 @@
-{%  include "django/forms/field.html" %}
-<span class="info-text info-text--form">Die Leistung Ihrer PV-Batterie finden Sie in den Kaufunterlagen, dem Anlagenzertifikat, auf dem Display des Batteriesystems, im Benutzerhandbuch oder über ein Online-Portal oder eine App des Anbieters.</span>

--- a/building_dialouge_webapp/templates/forms/pv-capacity.html
+++ b/building_dialouge_webapp/templates/forms/pv-capacity.html
@@ -1,2 +1,0 @@
-{%  include "django/forms/field.html" %}
-<span class="info-text info-text--form">Die PV-Leistung Ihrer Solaranlage finden Sie in den Kaufunterlagen, dem Anlagenzertifikat, auf dem Display des Wechselrichters, im Energieausweis oder über ein Online-Portal oder eine App des Anbieters.</span>

--- a/building_dialouge_webapp/templates/pages/building_type.html
+++ b/building_dialouge_webapp/templates/pages/building_type.html
@@ -16,10 +16,21 @@
       <div class="help"></div>
     </div>
     <div id="building_type" hx-post="" hx-trigger="change" hx-swap="show:bottom" hx-include="this">{{ building_type.content | safe }}</div>
-        <div id="monument_protection"
+    <div class="step-question">
+      <div class="step-container">
+        <div id="building_details"
           hx-post=""
-          hx-trigger="change"
+          hx-trigger="keyup change delay:1000ms"
           hx-swap="show:bottom"
-          hx-include="this">{{ monument_protection.content | safe }}</div>
+          hx-include="this"
+          class="main">{{ building_details.content | safe }}</div>
+        <div class="help"></div>
+      </div>
+    </div>
+    <div id="monument_protection"
+      hx-post=""
+      hx-trigger="change"
+      hx-swap="show:bottom"
+      hx-include="this">{{ monument_protection.content | safe }}</div>
   </section>
 {% endblock content %}

--- a/building_dialouge_webapp/templates/pages/heating.html
+++ b/building_dialouge_webapp/templates/pages/heating.html
@@ -7,7 +7,9 @@
         <div class="main">
           <h1>Heizung</h1>
           <div class="info-box">
-            <p>Hier erfassen wir die Technologie, mit der Ihr Gebäude beheizt wird. Diese Informationen sind wichtig, um den aktuellen Energiebedarf Ihres Gebäudes besser einzuschätzen.</p>
+            <p>In diesem Abschnitt erfassen wir, wie in Ihrem Gebäude Warmwasser erzeugt wird. Diese Informationen sind wichtig, um den aktuellen Energiebedarf Ihres Gebäudes besser einzuschätzen.
+            </p>
+            <p>Tragen Sie bitte die Ihnen bekannten Werte ein. Falls Sie keine genauen Angaben haben, genügt auch eine Schätzung.</p>
             <p>Wählen Sie bitte die primäre Heizungsart Ihres Gebäudes aus:</p>
           </div>
         </div>

--- a/building_dialouge_webapp/templates/partials/building_type_help.html
+++ b/building_dialouge_webapp/templates/partials/building_type_help.html
@@ -1,12 +1,21 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Geben Sie zunächst an, ob es sich um ein <b>Einfamilienhaus, Mehrfamilienhaus oder Reihenhaus</b> handelt.
+                Diese Angabe ist entscheidend, um Ihr Gebäude einer passenden <b>Gebäudetypologie</b> zuzuordnen.</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
-      <div class="info-text">
-        <p>Geben Sie zunächst an, ob es sich um ein <b>Einfamilienhaus, Mehrfamilienhaus oder Reihenhaus</b> handelt.
-        Diese Angabe ist entscheidend, um Ihr Gebäude einer passenden <b>Gebäudetypologie</b> zuzuordnen.</p>
-      </div>
     </div>
   </div>
 </div>

--- a/building_dialouge_webapp/templates/partials/building_type_protection_help.html
+++ b/building_dialouge_webapp/templates/partials/building_type_protection_help.html
@@ -1,11 +1,20 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Ein Gebäude oder ein Objekt, das wegen seiner besonderen geschichtlichen, kulturellen oder architektonischen Bedeutung geschützt ist. Denkmalgeschützte Gebäude sind in Denkmalliste zusammengefasst, die Sie bei Ihrer zuständigen Denkmalbehörde einsehen können.</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
-      <div class="info-text">
-        <p>Ein Gebäude oder ein Objekt, das wegen seiner besonderen geschichtlichen, kulturellen oder architektonischen Bedeutung geschützt ist. Denkmalgeschützte Gebäude sind in Denkmalliste zusammengefasst, die Sie bei Ihrer zuständigen Denkmalbehörde einsehen können.</p>
-      </div>
     </div>
   </div>
 </div>

--- a/building_dialouge_webapp/templates/partials/heating_solar_help.html
+++ b/building_dialouge_webapp/templates/partials/heating_solar_help.html
@@ -1,12 +1,23 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Eine Solarthermie-Anlage wandelt Sonnenlicht mithilfe von Kollektoren (Flach- oder
+                  Vakuumröhrenkollektoren) in Wärme um. Diese wird über eine Trägerflüssigkeit weitergeleitet und für
+                  Warmwasser oder zur Heizungsunterstützung genutzt.</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
       <div class="info-text">
-        <p>Eine Solarthermie-Anlage wandelt Sonnenlicht mithilfe von Kollektoren (Flach- oder
-          Vakuumröhrenkollektoren) in Wärme um. Diese wird über eine Trägerflüssigkeit weitergeleitet und für
-          Warmwasser oder zur Heizungsunterstützung genutzt.</p>
         <p><b>Woran erkenne ich eine Solarthermie-Anlage?</b></p>
         <div class="category-content">
           <ul>

--- a/building_dialouge_webapp/templates/partials/heating_solar_help.html
+++ b/building_dialouge_webapp/templates/partials/heating_solar_help.html
@@ -8,7 +8,12 @@
               <div class="info-text">
                 <p>Eine Solarthermie-Anlage wandelt Sonnenlicht mithilfe von Kollektoren (Flach- oder
                   Vakuumröhrenkollektoren) in Wärme um. Diese wird über eine Trägerflüssigkeit weitergeleitet und für
-                  Warmwasser oder zur Heizungsunterstützung genutzt.</p>
+                  Warmwasser oder zur Heizungsunterstützung genutzt. <span class="info-icon" data-tooltip="Woran erkenne ich eine Solarthermie-Anlage? -
+                  Dunkle Kollektoren auf dem Dach, schmaler und weniger glänzend als Solarmodule -
+                  Zusätzliche Wärmespeicher mit Solaranschlüssen im Heizungsraum -
+                  Hinweise in den Heizungsunterlagen oder Auskunft von Hausverwaltung/Installateur.
+                Falls Sie unsicher sind, werfen Sie einen Blick aufs Dach oder in den Heizraum, oft geben diese
+              Merkmale erste Hinweise.">I</span></p>
               </div>
               {{ field }}
               {% if field.help_text %}
@@ -17,18 +22,6 @@
           </div>
       {% endfor %}
       {% csrf_token %}
-      <div class="info-text">
-        <p><b>Woran erkenne ich eine Solarthermie-Anlage?</b></p>
-        <div class="category-content">
-          <ul>
-            <li><b>Dunkle Kollektoren auf dem Dach</b>, schmaler und weniger glänzend als Solarmodule</li>
-            <li><b>Zusätzliche Wärmespeicher</b> mit Solaranschlüssen im Heizungsraum</li>
-            <li><b>Hinweise in den Heizungsunterlagen</b> oder Auskunft von Hausverwaltung/Installateur</li>
-          </ul>
-          <p>Falls Sie unsicher sind, werfen Sie einen Blick aufs Dach oder in den Heizraum - oft geben diese
-              Merkmale erste Hinweise.</p>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/building_dialouge_webapp/templates/partials/heating_storage_help.html
+++ b/building_dialouge_webapp/templates/partials/heating_storage_help.html
@@ -1,7 +1,19 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Das Fassungsvermögen eines Wärmespeichers hängt von der Größe des Gebäudes und dem individuellen Wärmebedarf ab, wobei gängige Größen zwischen 300 und 1.000 Litern liegen, um ausreichend Warmwasser und Heizenergie bereitstellen zu können.</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
     </div>
   </div>

--- a/building_dialouge_webapp/templates/partials/pv_system_battery_help.html
+++ b/building_dialouge_webapp/templates/partials/pv_system_battery_help.html
@@ -1,7 +1,19 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Die Leistung Ihrer PV-Batterie finden Sie in den Kaufunterlagen, dem Anlagenzertifikat, auf dem Display des Batteriesystems, im Benutzerhandbuch oder über ein Online-Portal oder eine App des Anbieters.</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
     </div>
   </div>

--- a/building_dialouge_webapp/templates/partials/pv_system_capacity_help.html
+++ b/building_dialouge_webapp/templates/partials/pv_system_capacity_help.html
@@ -1,7 +1,19 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Die PV-Leistung Ihrer Solaranlage finden Sie in den Kaufunterlagen, dem Anlagenzertifikat, auf dem Display des Wechselrichters, im Energieausweis oder über ein Online-Portal oder eine App des Anbieters.</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
     </div>
   </div>

--- a/building_dialouge_webapp/templates/partials/roof_help.html
+++ b/building_dialouge_webapp/templates/partials/roof_help.html
@@ -1,7 +1,19 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Besitzt ihr Gebäude ein Flachdach?</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
     </div>
   </div>

--- a/building_dialouge_webapp/templates/partials/roof_inclination_help.html
+++ b/building_dialouge_webapp/templates/partials/roof_inclination_help.html
@@ -1,12 +1,25 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Die Dachneigung beschreibt den Winkel, in dem die Dachfläche zur Horizontalen geneigt ist, und wird in Grad (°) angegeben. In der Solarthermie beeinflusst sie die Effizienz der Solarkollektoren, da sie den Einfallswinkel des Sonnenlichts bestimmt.
+                <b><a href="https://http.cat/status/404"
+                target="_blank"
+                rel="noopener noreferrer">
+                  (So berechne ich die Dachneigung)
+                </a></b></p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
-      <div class="info-text">
-        <p>Die Dachneigung beschreibt den Winkel, in dem die Dachfläche zur Horizontalen geneigt ist, und wird in Grad (°) angegeben. In der Solarthermie beeinflusst sie die Effizienz der Solarkollektoren, da sie den Einfallswinkel des Sonnenlichts bestimmt.
-<b><a href="https://http.cat/status/404" target="_blank" rel="noopener noreferrer">(So berechne ich die Dachneigung)</a></b></p>
-      </div>
     </div>
   </div>
 </div>

--- a/building_dialouge_webapp/templates/partials/roof_orientation_help.html
+++ b/building_dialouge_webapp/templates/partials/roof_orientation_help.html
@@ -1,11 +1,20 @@
 <div class="step-question">
   <div class="step-container">
     <div class="main">
-      {{ form }}
+      {% for field in form %}
+          <div class="fieldWrapper">
+              {{ field.errors }}
+              {{ field.label_tag }}
+              <div class="info-text">
+                <p>Wählen Sie die Himmelsrichtung, in die Ihr Dach überwiegend zeigt: Norden (N), Nordosten (NO), Osten (O), Südosten (SO), Süden (S), Südwesten (SW), Westen (W) oder Nordwesten (NW).</p>
+              </div>
+              {{ field }}
+              {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+              {% endif %}
+          </div>
+      {% endfor %}
       {% csrf_token %}
-      <div class="info-text">
-        <p>Wählen Sie die Himmelsrichtung, in die Ihr Dach überwiegend zeigt: Norden (N), Nordosten (NO), Osten (O), Südosten (SO), Süden (S), Südwesten (SW), Westen (W) oder Nordwesten (NW).</p>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
moved the texts described [here](https://github.com/rl-institut/bd_app/issues/144#issuecomment-2839384902)
also checked with the presentation and found pv battery capacity, which needed to be moved for consistency.

And found a text that was different, so I updated the heating intro/info text:
![image](https://github.com/user-attachments/assets/691d4cc9-dd4f-40e5-ab53-15227579e88c)

Will post the moved texts screenshots below: