### PR TITLE
Feature/preselected energy in renovation

### DIFF
--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -362,6 +362,27 @@ class RenovationTechnologyForm(ValidationForm):
     )
 
 
+def disable_only_sth(self, data):
+    solar_thermal_exists = data.get("solar_thermal_exists", None)
+    if solar_thermal_exists == "True":
+        self.fields["secondary_heating"].disabled = True
+        self.fields["secondary_heating"].initial = ["solar"]
+
+
+def disable_sth_pv(self, data):
+    pv_exists = data.get("pv_exists", None)
+    solar_thermal_exists = data.get("solar_thermal_exists", None)
+    if solar_thermal_exists == "True" and pv_exists == "True":
+        self.fields["secondary_heating"].disabled = True
+        self.fields["secondary_heating"].initial = ["solar", "pv"]
+    elif solar_thermal_exists == "True":
+        self.fields["secondary_heating"].disabled = True
+        self.fields["secondary_heating"].initial = ["solar"]
+    elif pv_exists == "True":
+        self.fields["secondary_heating"].disabled = True
+        self.fields["secondary_heating"].initial = ["pv"]
+
+
 class RenovationSolarForm(ValidationForm):
     secondary_heating = forms.MultipleChoiceField(
         label="Zusätzliche Erzeuger",
@@ -372,6 +393,10 @@ class RenovationSolarForm(ValidationForm):
         required=False,
     )
     secondary_heating_hidden = forms.CharField(widget=forms.HiddenInput(), required=False, initial="none")
+
+    def validate_with_session(self):
+        data = self.request.session.get("django_htmx_flow", {})
+        disable_only_sth(self, data)
 
 
 class RenovationPVSolarForm(ValidationForm):
@@ -385,6 +410,10 @@ class RenovationPVSolarForm(ValidationForm):
         required=False,
     )
     secondary_heating_hidden = forms.CharField(widget=forms.HiddenInput(), required=False, initial="none")
+
+    def validate_with_session(self):
+        data = self.request.session.get("django_htmx_flow", {})
+        disable_sth_pv(self, data)
 
 
 class RenovationBioMassForm(ValidationForm):
@@ -406,6 +435,10 @@ class RenovationBioMassForm(ValidationForm):
         required=False,
     )
     secondary_heating_hidden = forms.CharField(widget=forms.HiddenInput(), required=False, initial="none")
+
+    def validate_with_session(self):
+        data = self.request.session.get("django_htmx_flow", {})
+        disable_only_sth(self, data)
 
 
 class RenovationHeatPumpForm(ValidationForm):
@@ -430,6 +463,10 @@ class RenovationHeatPumpForm(ValidationForm):
         required=False,
     )
     secondary_heating_hidden = forms.CharField(widget=forms.HiddenInput(), required=False, initial="none")
+
+    def validate_with_session(self):
+        data = self.request.session.get("django_htmx_flow", {})
+        disable_sth_pv(self, data)
 
 
 class RenovationRequestForm(ValidationForm):

--- a/building_dialouge_webapp/static/css/components/_forms.scss
+++ b/building_dialouge_webapp/static/css/components/_forms.scss
@@ -52,6 +52,12 @@ fieldset legend {
       color: $grey-800;
       font-weight: 400;
     }
+
+    &:has(> input[type="checkbox"]:disabled),
+    &:has(> input[type="radio"]:disabled) {
+      color: $grey-400;
+      font-weight: 400;
+    }
   }
 
   input[type="checkbox"],
@@ -126,6 +132,11 @@ fieldset legend {
   select:focus {
     border-color: $green-500;
     box-shadow: 0 0 5px rgba(40, 167, 69, 0.5);
+  }
+
+  input[type="checkbox"]:disabled,
+  input[type="radio"]:disabled {
+    pointer-events: none;
   }
 
   select {


### PR DESCRIPTION
managed to disable a whole field in first commit, then I realized that for "Wärmepumpe" for example pv and sth are just 2 of 4 options and the others should not be disabled as well. Thats why I tried using this [example](https://stackoverflow.com/questions/48935945/disable-choice-in-modelmultiplechoicefield-checkboxselectmultiple-django) to just disable the pv and sth options, but I did not manage to make them work. They are not rendered for me...