### PR TITLE
Features/kick changing to oil

### DIFF
--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -360,7 +360,7 @@ class RenovationTechnologyForm(ValidationForm):
             ("district_heating", "Fernwärme"),
             ("bio_mass", "Biomasseheizung"),
             ("heat_pump", "Wärmepumpe"),
-            ("oil_heating", "Effiziente Öl- und Gasheizung"),
+            ("oil_heating", "Effiziente Gasheizung"),
             ("heating_rod", "Heizstab"),
             ("bhkw", "BHKW"),
         ],
@@ -435,7 +435,7 @@ class RenovationHeatPumpForm(SecondaryHeatingForm):
         widget=forms.RadioSelect,
     )
     secondary_heating_choices = [
-        ("oil_heating", "Effiziente Öl- und Gasheizung"),
+        ("oil_heating", "Effiziente Gasheizung"),
         ("heating_rod", "Heizstab"),
         ("pv", "PV-Anlage"),
         ("solar", "Solarthermie"),

--- a/building_dialouge_webapp/heat/forms.py
+++ b/building_dialouge_webapp/heat/forms.py
@@ -360,7 +360,7 @@ class RenovationTechnologyForm(ValidationForm):
             ("district_heating", "Fernwärme"),
             ("bio_mass", "Biomasseheizung"),
             ("heat_pump", "Wärmepumpe"),
-            ("oil_heating", "Effiziente Gasheizung"),
+            ("gas_heating", "Effiziente Gasheizung"),
             ("heating_rod", "Heizstab"),
             ("bhkw", "BHKW"),
         ],
@@ -435,7 +435,7 @@ class RenovationHeatPumpForm(SecondaryHeatingForm):
         widget=forms.RadioSelect,
     )
     secondary_heating_choices = [
-        ("oil_heating", "Effiziente Gasheizung"),
+        ("gas_heating", "Effiziente Gasheizung"),
         ("heating_rod", "Heizstab"),
         ("pv", "PV-Anlage"),
         ("solar", "Solarthermie"),

--- a/building_dialouge_webapp/heat/hooks.py
+++ b/building_dialouge_webapp/heat/hooks.py
@@ -383,10 +383,10 @@ def set_up_conversion_technologies(
             }
     # Bivalent system HP + Oil/Gas
     # Set lowest capacity for secondary heating
-    if "oil_heating" in parameters["flow_data"]["scenario-secondary_heating"]:
+    if "gas_heating" in parameters["flow_data"]["scenario-secondary_heating"]:
         parameters["oeprom"]["conversion_boiler"] = {
             "expandable": True,
-            "capacity_cost": settings.get_ep_cost("oil_heating", 10),
+            "capacity_cost": settings.get_ep_cost("gas_heating", 10),
             "capacity_potential": 10,
         }
     return parameters

--- a/building_dialouge_webapp/heat/hooks.py
+++ b/building_dialouge_webapp/heat/hooks.py
@@ -371,7 +371,7 @@ def set_up_conversion_technologies(
         "wood_pellets": "conversion_pk",
         "wood_chips": "conversion_hgk",
         "firewood": "conversion_shk",
-        "oil_heating": "conversion_boiler",
+        "gas_heating": "conversion_boiler",
         "heating_rod": "conversion_ehz",
         "bhkw": "backpressure_bhkw",
     }

--- a/building_dialouge_webapp/templates/pages/intro_renovation.html
+++ b/building_dialouge_webapp/templates/pages/intro_renovation.html
@@ -24,7 +24,7 @@
             <li>Fernwärme</li>
             <li>Biomasseheizung</li>
             <li>Wärmepumpe</li>
-            <li>Effiziente Öl- und Gasheizung</li>
+            <li>Effiziente Gasheizung</li>
             <li>Heizstab</li>
             <li>BHKW</li>
           </ul>

--- a/scripts/django_oemof_standalone.py
+++ b/scripts/django_oemof_standalone.py
@@ -45,7 +45,7 @@ PARAMETERS = {
         "financial_support_done": "True",
         "hotwater_supply": "instantaneous_water_heater",
         "scenario1-heat_pump_type": "air_heat_pump",
-        "scenario1-secondary_heating": ["pv", "oil_heating"],
+        "scenario1-secondary_heating": ["pv", "gas_heating"],
         "scenario1-secondary_heating_hidden": "none",
         "scenario1-facade_renovation": False,
         "scenario1-roof_renovation": False,


### PR DESCRIPTION
So far, only one component of a new heating technology for oil and gas heating has been included in OEPROM.

As we won't be simulating a case involving a new oil heating system, we will maintain an efficient gas heating system and abandon oil. 

These changes do not apply for a existing oil heating. But it is not possible to replace an old heating system with a new oil heating system.